### PR TITLE
View component updates, and Spina Part registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage
 Gemfile.lock
 spec/examples.txt
 *.gem
+.DS_Store

--- a/app/views/spina/admin/case_studies/case_studies/_form.html.erb
+++ b/app/views/spina/admin/case_studies/case_studies/_form.html.erb
@@ -1,14 +1,14 @@
 <div data-controller="tabs" data-tabs-active="cursor-default text-gray-900 bg-spina-dark bg-opacity-10" data-tabs-inactive="cursor-pointer bg-transparent text-gray-400 border-transparent">
   <%= render Spina::UserInterface::HeaderComponent.new do |header| %>
-    <% header.actions do %>
+    <% header.with_actions do %>
       <% if @case_study.persisted? %>
         <!-- Translations -->
         <%= render Spina::Pages::TranslationsComponent.new(@case_study, label: @locale.upcase) %>
         <%= render Spina::UserInterface::DropdownComponent.new do |dropdown| %>
-          <% dropdown.button(classes: "btn btn-default px-3") do %>
+          <% dropdown.with_button(classes: "btn btn-default px-3") do %>
             <%= heroicon('dots-horizontal', style: :solid, class: "w-5 h-5 text-gray-600") %>
           <% end %>
-          <% dropdown.menu do %>
+          <% dropdown.with_menu do %>
             <%= button_to t('spina.permanently_delete'), spina.admin_case_studies_case_study_path(@case_study.id), method: :delete, class: "block w-full text-left px-4 py-2 text-sm leading-5 font-medium text-red-500 cursor-pointer bg-white hover:bg-red-100 hover:bg-opacity-50 hover:text-red-500 focus:outline-none focus:bg-gray-100 focus:text-gray-900", form: {data: {controller: "confirm", confirm_message: t('spina.case_studies.case_studies.delete_confirmation', subject: @case_study.title)}} %>
           <% end %>
         <% end %>
@@ -18,7 +18,7 @@
         <%=t 'spina.case_studies.case_studies.save' %>
       <% end %>
     <% end %>
-    <% header.navigation do %>
+    <% header.with_navigation do %>
       <nav class="-mb-3 mt-4">
         <ul class="inline-flex w-auto rounded-md bg-white">
           <% @tabs.each do |tab| %>

--- a/app/views/spina/admin/case_studies/case_studies/index.html.erb
+++ b/app/views/spina/admin/case_studies/case_studies/index.html.erb
@@ -1,10 +1,10 @@
 <%= render Spina::UserInterface::HeaderComponent.new do |header| %>
-  <% header.after_breadcrumbs do %>
+  <% header.with_after_breadcrumbs do %>
     <%= link_to spina.new_admin_case_studies_case_study_path, class: 'btn btn-default h-8 px-2 ml-3' do %>
       <%= heroicon('plus', style: :solid, class: 'w-6 h-6') %>
     <% end %>
   <% end %>
-  <% header.navigation do %>
+  <% header.with_navigation do %>
     <nav class="-mb-3 mt-4">
       <ul class="inline-flex w-auto rounded-md bg-white">
         <%= render Spina::UserInterface::TabLinkComponent.new(t('spina.case_studies.case_studies.all_case_studies'), spina.admin_case_studies_case_studies_path, active: action_name == 'index') %>

--- a/app/views/spina/admin/case_studies/testimonials/_form.html.erb
+++ b/app/views/spina/admin/case_studies/testimonials/_form.html.erb
@@ -1,14 +1,14 @@
 <div data-controller="tabs" data-tabs-active="cursor-default text-gray-900 bg-spina-dark bg-opacity-10" data-tabs-inactive="cursor-pointer bg-transparent text-gray-400 border-transparent">
   <%= render Spina::UserInterface::HeaderComponent.new do |header| %>
-    <% header.actions do %>
+    <% header.with_actions do %>
       <% if @testimonial.persisted? %>
         <!-- Translations -->
         <%= render Spina::Pages::TranslationsComponent.new(@testimonial, label: @locale.upcase) %>
         <%= render Spina::UserInterface::DropdownComponent.new do |dropdown| %>
-          <% dropdown.button(classes: "btn btn-default px-3") do %>
+          <% dropdown.with_button(classes: "btn btn-default px-3") do %>
             <%= heroicon('dots-horizontal', style: :solid, class: "w-5 h-5 text-gray-600") %>
           <% end %>
-          <% dropdown.menu do %>
+          <% dropdown.with_menu do %>
             <%= button_to t('spina.permanently_delete'), spina.admin_case_studies_testimonial_path(@testimonial.id), method: :delete, class: "block w-full text-left px-4 py-2 text-sm leading-5 font-medium text-red-500 cursor-pointer bg-white hover:bg-red-100 hover:bg-opacity-50 hover:text-red-500 focus:outline-none focus:bg-gray-100 focus:text-gray-900", form: {data: {controller: "confirm", confirm_message: t('spina.case_studies.case_studies.delete_confirmation', subject: @testimonial.name)}} %>
           <% end %>
         <% end %>
@@ -18,7 +18,7 @@
         <%=t 'spina.case_studies.case_studies.save' %>
       <% end %>
     <% end %>
-    <% header.navigation do %>
+    <% header.with_navigation do %>
       <nav class="-mb-3 mt-4">
         <ul class="inline-flex w-auto rounded-md bg-white">
           <% @tabs.each do |tab| %>

--- a/app/views/spina/admin/case_studies/testimonials/index.html.erb
+++ b/app/views/spina/admin/case_studies/testimonials/index.html.erb
@@ -1,5 +1,5 @@
 <%= render Spina::UserInterface::HeaderComponent.new do |header| %>
-  <% header.after_breadcrumbs do %>
+  <% header.with_after_breadcrumbs do %>
     <%= link_to spina.new_admin_case_studies_testimonial_path, class: 'btn btn-default h-8 px-2 ml-3' do %>
       <%= heroicon('plus', style: :solid, class: 'w-6 h-6') %>
     <% end %>

--- a/app/views/spina/admin/hooks/case_studies/_primary_navigation.html.erb
+++ b/app/views/spina/admin/hooks/case_studies/_primary_navigation.html.erb
@@ -1,11 +1,11 @@
 <%= render Spina::MainNavigation::SubNavComponent.new(:case_studies) do |nav| %>
-  <% nav.icon do %>
+  <% nav.with_icon do %>
     <%= heroicon('chart-bar', style: :solid, class: 'w-8 h-8 text-white md:mr-3') %>
     <div class="text-white font-semibold hidden md:block transform -translate-x-2 ease-in-out duration-300 absolute md:relative opacity-0 transition-all" data-navigation-target="label">
       <%=t 'spina.case_studies.title' %>
     </div>
   <% end %>
-  <% nav.links do %>
+  <% nav.with_links do %>
     <%= render Spina::MainNavigation::LinkComponent.new(t('spina.case_studies.case_studies.title'), admin_case_studies_case_studies_path, active: request.path.start_with?("/#{Spina.config.backend_path}/case_studies")) %>
     <%= render Spina::MainNavigation::LinkComponent.new(t('spina.case_studies.testimonials.title'), admin_case_studies_testimonials_path, active: request.path.start_with?("/#{Spina.config.backend_path}/testimonials")) %>
   <% end %>

--- a/app/views/spina/admin/parts/case_studies/_form.html.erb
+++ b/app/views/spina/admin/parts/case_studies/_form.html.erb
@@ -1,0 +1,6 @@
+<div class="mt-6">
+  <%= f.label :case_study_id, f.object.title, class: 'block text-sm leading-5 font-medium text-gray-700' %>
+  <div class="mt-1">
+    <%= f.select :case_study_id, Spina::CaseStudies::CaseStudy.all.pluck(:title, :id), { include_blank: true }, { class: 'form-input block w-full max-w-5xl sm:text-sm sm:leading-5' } %>
+  </div>
+</div>

--- a/lib/spina/case_studies/railtie.rb
+++ b/lib/spina/case_studies/railtie.rb
@@ -11,6 +11,12 @@ module Spina
         end
       end
 
+      initializer 'spina_case_studies.register_parts' do |app|
+        app.reloader.to_prepare do
+          Spina::Part.register(Spina::Parts::CaseStudy)
+        end
+      end
+
       initializer 'spina_case_studies.assets.precompile' do |app|
         app.config.assets.precompile += %w[spina/case_studies/admin/case_studies.js]
       end


### PR DESCRIPTION
Latest version of the View Component gem was having issues due to the new rendering `with_` prefix, this was causing forms to not render in the CMS. Updates here apply the prefix.

Also the Case Study Spina::Part was not registered, and missing a form - I've included both of those, at the moment this would still require you define the part in your theme initializer, but otherwise allows this to work with no additional config.